### PR TITLE
Adds the papers of the Software Composition Group form the university of Berne

### DIFF
--- a/_research/papers-2000.md
+++ b/_research/papers-2000.md
@@ -1,0 +1,6 @@
+---
+order:      2000 
+category:   2000 
+---
+Ducasse Stéphane, Serge Demeyer, and Oscar Nierstrasz. Tie Code And Questions: a Reengineering Pattern. In: Proceedings of the 5th European Conference on Pattern Languages of Programms p.209–218, 2000, Universitätsverlag Konstanz, Irsee, Germany.
+Ducasse Stéphane, Oscar Nierstrasz, and Serge Demeyer. Transform Conditionals to Polymorphism. In: Proceedings of the 5th European Conference on Pattern Languages of Programms p.219–252, 2000, Universitätsverlag Konstanz, Irsee, Germany.

--- a/_research/papers-2001.md
+++ b/_research/papers-2001.md
@@ -1,0 +1,5 @@
+---
+order:      2001
+category:   2001
+---
+Schärli Nathanael, and Franz Achermann. Partial Evaluation of Inter-Language Wrappers. 2001, Vienna, Austria.

--- a/_research/papers-2002.md
+++ b/_research/papers-2002.md
@@ -1,0 +1,6 @@
+---
+order:      2002
+category:   2002
+---
+Ducasse Stéphane, Roel Wuyts, and others. Supporting Objects as An Anthropomorphic View at Computation or Why Smalltalk for Teaching Objects? 2002.
+Schaerli Nathanael, Stéphane Ducasse, and Oscar Nierstrasz. Classes = traits + states + glue. In: Proceedings of The Inheritance Workshop at ECOOP 2002 p.82-88, 2002, Springer, Málaga, Spain.

--- a/_research/papers-2003.md
+++ b/_research/papers-2003.md
@@ -5,3 +5,21 @@ category:   2003
 Sergei Kojarski, Karl Lieberherr, David H. Lorenz, and Robert Hirschfeld. Aspectual Reflection. In Proceedings of the 2003 International Workshop on Software Engineering Properties of Languages for Aspect Technologies (SPLAT), co-located with the 2nd International Conference on Aspect-Oriented Software Development (AOSD) 2003, Boston, Massachusetts, USA, March 17-21, 2003.
 
 Robert Hirschfeld. AspectS â€“ Aspect-oriented Programming with Squeak. In Mehmet Aksit, Mira Mezini, and Rainer Unland (eds.), Proceedings of Objects, Components, Architectures, Services, and Applications for a Networked World, Springer LNCS 2591, pages 216-232, Springer, 2003.
+
+Bergel Alexandre, Stéphane Ducasse, and Roel Wuyts. Classboxes: A Minimal Module Model Supporting Local Rebinding. In: Modular Programming Languages p.122–131, 2003, Springer Berlin Heidelberg.
+
+Bergel Alexandre, Stéphane Ducasse, and Roel Wuyts. The Classbox module system. In: Object-Oriented Technology: ECOOP 2003 Workshop Reader ECOOP, Final Reports No. 3 , 2003, Springer, Darmstadt, Germany.
+
+Black Andrew P., Nathanael Schärli, and Stéphane Ducasse. Applying traits to the smalltalk collection classes. In: Proceedings of the 2003 ACM SIGPLAN Conference on Object-Oriented Programming Systems, Languages and Applications p.47–64, 2003, ACM, Anaheim, CA, USA.
+
+Ducasse Stéphane, and Sander Tichelaar. Dimensions of reengineering environment infrastructures. In: Journal of Software Maintenance and Evolution: Research and Practice No. 15 p.345–373, 2003.
+
+Markus Gaelli. Test composition with example objects and example methods. In: Object-Oriented Technology: ECOOP 2003 Workshop Reader ECOOP, Final Reports No. 3 , 2003, Springer, Darmstadt, Germany.
+
+Mougin Philippe, and Stéphane Ducasse. Oopal: integrating array programming in object-oriented programming. In: ACM SIGPLAN Notices No. 38 p.65–77, 2003, ACM.
+
+Nierstrasz Oscar, and Franz Achermann. A Calculus for Modeling Software Components. In: Formal Methods for Components and Objects p.339–360, 2003, Springer Berlin Heidelberg.
+
+Schaerli Nathanael, Roel Wuyts, and Ducasse Stéphane. Open Surfaces for Controlled Visibility. In: Object-Oriented Technology: ECOOP 2003 Workshop Reader ECOOP, Final Reports No. 3 , 2003, Springer, Darmstadt, Germany.
+
+Schärli Nathanael, Stéphane Ducasse, Oscar Nierstrasz, and Andrew P. Black. Traits: Composable Units of Behaviour. In: ECOOP 2003 – Object-Oriented Programming p.248–274, 2003, Springer Berlin Heidelberg.

--- a/_research/papers-2004.md
+++ b/_research/papers-2004.md
@@ -5,3 +5,31 @@ category:   2004
 Stefan Hanenberg, Robert Hirschfeld, and Rainer Unland. Morphing Aspects: Incompletely Woven Aspects and Continuous Weaving. In Proceedings of the 3rd International Conference on Aspect-oriented Software Development (AOSD) 2004, pages 46-55, ACM Press, Lancaster, UK, March 22-26, 2004.
 
 Robert Hirschfeld, Katsuya Kawamura, and Hendrik Berndt. Dynamic Service Adaptation for Runtime System Extensions. In Roberto Battiti, Renato Lo Cigno Cigno, Marco Conti (eds.), Proceedings of Wireless On-Demand Network Systems (WONS) 2004, Springer LNCS 2928, pages 227-240, Springer, 2004.
+
+Black Andrew P., and Nathanael Scharli. Traits: Tools and methodology. In: Proceedings of the 26th International Conference on Software Engineering p.676–686, 2004, IEEE Computer Society.
+
+Gaelli Markus, Oscar Nierstrasz, and Stéphane Ducasse. One-method commands: Linking methods and their tests. In: OOPSLA Workshop on Revival of Dynamic Languages (October 2004), 2004, Citeseer.
+
+Gälli Markus. Correlating unit tests and methods under test. In: Extreme Programming and Agile Processes in Software Engineering p.317–317, 2004, Springer.
+
+Gälli Markus, Michele Lanza, Oscar Nierstrasz, and Roel Wuyts. Ordering broken unit tests for focused debugging. In: Software Maintenance, 2004. Proceedings. 20th IEEE International Conference on p.114–123, 2004, IEEE.
+
+Lienhard Adrian. Bootstrapping Traits. In: Master’s thesis, University of Bern, 2004.
+
+Nierstrasza Alexandre Bergela Stéphane Ducassea Oscar, and Roel Wuytsb. Classboxes: Controlling Visibility of Class Extensions. In: ESUG 2004 Research Track p.183, 2004.
+
+Nierstrasz Oscar, and Franz Achermann. Separating concerns with first-class namespaces. In: Robert E. Filman, Tzilla Elrad, Siobhán Clarke, and sit Mehmet Ak editors, Aspect-Oriented Software Development p.243–259, 2004.
+
+Nierstrasz Oscar, and Marcus Denker. Supporting software change in the programming language. In: OOPSLA Workshop on Revival of Dynamic Languages, 2004.
+
+Rengglib Stéphane Ducassea Adrian Lienhardb Lukas. Seaside–A Multiple Control Flow Web Application Framework. In: Proceedings ESUG 2004 International Conference--Research Track, volume Technical Report IAM-04-008, 2004.
+
+Schärli Nathanael, and Andrew P. Black. A browser for incremental programming. In: Computer Languages, Systems & Structures No. 30 p.79–95, 2004.
+
+Schärli Nathanael, Andrew P. Black, and Stéphane Ducasse. Object-oriented encapsulation for dynamically typed languages. In: ACM SIGPLAN Notices No. 39 p.130–149, 2004, ACM.
+
+Schärli Nathanael, Stéphane Ducasse, Oscar Nierstrasz, and Roel Wuyts. Composable encapsulation policies. In: ECOOP 2004–Object-Oriented Programming p.26–50, 2004, Springer.
+
+Wuytsb Stéphane Ducassea Nathanael Schärlia Roel. Uniform and Safe Metaclass Composition. In: ESUG 2004 Research Track p.157, 2004.
+
+Wuyts Roel, and Stéphane Ducasse. Unanticipated integration of development tools using the classification model. In: Computer languages, systems & structures No. 30 p.63–77, 2004.

--- a/_research/papers-2005.md
+++ b/_research/papers-2005.md
@@ -7,3 +7,29 @@ Robert Hirschfeld and Stefan Hanenberg. Open Aspects. In Elsevier Journal on Com
 Pascal Costanza and Robert Hirschfeld. Language Constructs for Context-oriented Programming - An Overview of ContextL. In Proceedings of the Dynamic Languages Symposium (DLS) 2005, co-located with the Conference on Object-oriented Programming, Systems, Languages, and Applications (OOPSLA) 2005, San Diego, California, USA, October 18, 2005, ACM DL.
 
 Robert Hirschfeld and Ralf LÃ¤mmel. Reflective Designs. In IEE Journal on Software, Special Issue on Reusable Software Libraries, vol. 152, no. 1, pages 38-51, February 2005.
+
+Achermann Franz, and Oscar Nierstrasz. A calculus for reasoning about software composition. In: Theoretical Computer Science No. 331 p.367–396, 2005.
+
+Bergel Alexandre, and Stéphane Ducasse. Scoped and dynamic aspects with Classboxes. In: L’Objet No. 11 p.53–68, 2005.
+
+Bergel Alexandre, Stéphane Ducasse, and Oscar Nierstrasz. Analyzing Module Diversity. In: J. UCS No. 11 p.1613–1644, 2005.
+
+Bergel Alexandre, Stéphane Ducasse, Oscar Nierstrasz, and Roel Wuyts. Classboxes: Controlling visibility of class extensions. In: Computer Languages, Systems & Structures No. 31 p.107–126, 2005.
+
+Ducasse Stéphane. Supporting unanticipated changes with traits and classboxes. In: In Proceedings of Net. ObjectDays (NODE’05, 2005.
+
+Ducasse Stéphane, and Michele Lanza. The class blueprint: visually supporting the understanding of glasses. In: Software Engineering, IEEE Transactions on No. 31 p.75–90, 2005.
+
+Ducasse Stéphane, Michele Lanza, and Laura Ponisio. Butterflies: A visual approach to characterize packages. In: Software Metrics, 2005. 11th IEEE International Symposium p.10–pp, 2005, IEEE.
+
+Ducasse Stéphane, Lukas Renggli, and Roel Wuyts. SmallWiki: a meta-described collaborative content management system. In: Proceedings of the 2005 international symposium on Wikis p.75–82, 2005, ACM.
+
+Ducasse Stéphane, Nathanael Schärli, and Roel Wuyts. Uniform and safe metaclass composition. In: Computer languages, systems & structures No. 31 p.143–164, 2005.
+
+Lienhard Adrian, Stéphane Ducasse, and Gabriela Arévalo. Identifying traits with formal concept analysis. In: Proceedings of the 20th IEEE/ACM international Conference on Automated software engineering p.66–75, 2005, ACM.
+
+Minjat Florian, Alexandre Bergel, Pierre Cointe, and Stéphane Ducasse. Mise en symbiose des traits et des classboxes. Application à l expression des collaborations. In: L’OBJET No. 11 p.33–46, 2005.
+
+Nierstrasza Markus Gällia Michele Lanzab Oscar. Towards a Taxonomy of SUnit tests. In: Proceedings of the International European Smalltalk Conference, 2005, University of Bern, Switzerland.
+
+Nierstrasz Oscar, Alexandre Bergel, Marcus Denker, Stéphane Ducasse, Markus Gälli, and Roel Wuyts. On the revival of dynamic languages. In: Software composition p.1–13, 2005, Springer.

--- a/_research/papers-2006.md
+++ b/_research/papers-2006.md
@@ -5,3 +5,29 @@ category:   2006
 Alexandre Bergel, Robert Hirschfeld, Siobhan Clarke, and Pascal Costanza. AspectBoxes - Controlling the Visibility of Aspects. In Proceedings of the First International Conference on Software and Data Technologies (ICSOFT) 2006, Springer CCIS 10, pages 74-83, Setubal, Portugal, September 11-14, 2006, Springer.
 
 Robert Hirschfeld and Katsuya Kawamura. Dynamic Service Adaptation. In Software: Practice and Experience, 36(11-12):1115-1131, September-October 2006, Wiley InterScience.
+
+Bergel Alexandre, and Marcus Denker. Prototyping Languages, Related Constructs and Tools with Squeak. In: ECOOP’06 Workshop on Revival of Dynamic Languages, 2006.
+
+Denker Marcus, Stéphane Ducasse, and Éric Tanter. Runtime bytecode transformation for Smalltalk. In: Computer Languages, Systems & Structures No. 32 p.125–139, 2006.
+
+Denker Marcus, Orla Greevy, and Michele Lanza. Higher abstractions for dynamic analysis. In: 2nd international workshop on program comprehension through dynamic analysis (PCODA 2006) p.32–38, 2006, Universiteit Antwerpen.
+
+Ducasse Stéphane, Oscar Nierstrasz, and Matthias Rieger. On the effectiveness of clone detection by string matching. In: Journal of Software Maintenance and Evolution: Research and Practice No. 18 p.37–58, 2006.
+
+Ducasse Stéphane, Oscar Nierstrasz, Nathanael Schärli, Roel Wuyts, and Andrew P. Black. Traits: A mechanism for fine-grained reuse. In: ACM Transactions on Programming Languages and Systems (TOPLAS) No. 28 p.331–388, 2006.
+
+Gaelli Markus. Modeling Examples to Test and Understand Software. 2006.
+
+Gaelli Markus, Orla Greevy, and Oscar Nierstrasz. Composing unit tests. In: 2nd International Workshop on Software Product Line Testing p.16–22, 2006.
+
+Gaelli Markus, Oscar Nierstrasz, and Serge Stinckwich. Idioms for composing games with etoys. In: Creating, Connecting and Collaborating through Computing, 2006. C5’06. The Fourth International Conference on p.222–231, 2006, IEEE.
+
+Hofer Christoph, Marcus Denker, and Stéphane Ducasse. Design and implementation of a backward-in-time debugger. In: NODe 2006 p.17–32, 2006, GI.
+
+Lienhard Adrian, Stéphane Ducasse, Tudor Girba, and Oscar Nierstrasz. Capturing how objects flow at runtime. In: Proceedings International Workshop on Program Comprehension through Dynamic Analysis (PCODA 2006) p.39–43, 2006.
+
+Nierstrasz Oscar, Marcus Denker, Tudor Girba, and Adrian Lienhard. Analyzing, capturing and taming software change. In: Workshop on Revival of Dynamic Languages (co-located with ECOOP’06), 2006.
+
+Nierstrasz Oscar, Stéphane Ducasse, and Nathanael Schärli. Flattening Traits. In: Journal of Object Technology No. 5 p.129–148, 2006.
+
+Thalmann Florian, and Markus Gaelli. Jam Tomorrow: Collaborative Music Generation in Croquet Using OpenAL. In: Creating, Connecting and Collaborating through Computing, 2006. C5’06. The Fourth International Conference on p.73–78, 2006, IEEE.

--- a/_research/papers-2007.md
+++ b/_research/papers-2007.md
@@ -7,3 +7,33 @@ Johan Brichau, Andy Kellens, Kris Gybels, Kim Mens, Robert Hirschfeld, and Theo 
 Michael Haupt, Robert Hirschfeld, and Marcus Denker. Type Feedback for Bytecode Interpreters. 2nd Workshop on Implementation, Compilation, Optimization of Object-oriented Languages, Programs and Systems (ICOOOLPS) 2007, co-located with the European Conference on Object-oriented Programming (ECOOP) 2007, Berlin, Germany, July 30, 2007.
 
 Johan Brichau, Andy Kellens, Kris Gybels, Kim Mens, Robert Hirschfeld, and Theo D'Hondt. Application-Specific Models and Pointcuts Using a Logic Meta Language. In Advances in Smalltalk, Springer LNCS 4406, pages 1-22, Springer, 2007.
+
+Bergel Alexandre. Classboxes–Controlling Visibility of Class Extensions (Classboxes–Kontrollierte Sichtbarkeit von Klassenerweiterungen). In: it–Information Technology (vormals it+ ti) No. 49 p.260–263, 2007.
+
+Bergel Alexandre, Stéphane Ducasse, Oscar Nierstrasz, and Roel Wuyts. Stateful traits. In: Advances in Smalltalk p.66–90, 2007, Springer.
+
+Bergel Alexandre, Stéphane Ducasse, Colin Putney, and Roel Wuyts. Meta-driven browsers. In: Lecture notes in computer science No. 4406 p.134–156, 2007.
+
+Denker Marcus, and Stéphane Ducasse. Software evolution from the field: an experience report from the Squeak maintainers. In: Electronic Notes in Theoretical Computer Science No. 166 p.81–91, 2007.
+
+Denker Marcus, Tudor Gîrba, Adrian Lienhard, Oscar Nierstrasz, Lukas Renggli, and Pascal Zumkehr. Encapsulating and exploiting change with changeboxes. In: Proceedings of the 2007 international conference on Dynamic languages: in conjunction with the 15th International Smalltalk Joint Conference 2007 p.25–49, 2007, ACM.
+
+Denker Marcus, Orla Greevy, and Oscar Nierstrasz. Supporting feature analysis with runtime annotations. In: 3rd International Workshop on Program Comprehension through Dynamic Analysis (PCODA 2007) p.29–33, 2007, Technische Universiteit Delft.
+
+Ducasse Stéphane, Roel Wuyts, Alexandre Bergel, and Oscar Nierstrasz. User-changeable visibility: Resolving unanticipated name clashes in traits. In: ACM SIGPLAN Notices No. 42 p.171–190, 2007, ACM.
+
+Lienhard Adrian, Orla Greevy, and Oscar Nierstrasz. Tracking objects to detect feature dependencies. In: Program Comprehension, 2007. ICPC’07. 15th IEEE International Conference on p.59–68, 2007, IEEE.
+
+Reichhart Stefan, Tudor Gîrba, and Stéphane Ducasse. Rule-based Assessment of Test Quality. In: Journal of Object Technology No. 6 p.231–251, 2007.
+
+Renggli Lukas, Stéphane Ducasse, and Adrian Kuhn. Magritte–a meta-driven approach to empower developers and end users. In: Model Driven Engineering Languages and Systems p.106–120, 2007, Springer.
+
+Renggli Lukas, and Oscar Nierstrasz. Transactional memory for Smalltalk. In: Proceedings of the 2007 international conference on Dynamic languages: in conjunction with the 15th International Smalltalk Joint Conference 2007 p.207–221, 2007, ACM.
+
+Röthlisberger David, Marcus Denker, and Éric Tanter. Unanticipated partial behavioral reflection. In: Advances in Smalltalk p.47–65, 2007, Springer.
+
+Röthlisberger David, Orla Greevy, and Adrian Lienhard. Feature-centric environment. In: Visualizing Software for Understanding and Analysis, 2007. VISSOFT 2007. 4th IEEE International Workshop on p.150–151, 2007, IEEE.
+
+Röthlisberger David, Orla Greevy, and Oscar Nierstrasz. Feature driven browsing. In: Proceedings of the 2007 international Conference on Dynamic Languages: in Conjunction with the 15th international Smalltalk Joint Conference 2007 p.79–100, 2007, ACM.
+
+Röthlisberger David, and Oscar Nierstrasz. Combining Development Environments with Reverse Engineering. In: Proceedings of FAMOOSr No. 2007 p.20, 2007.

--- a/_research/papers-2008.md
+++ b/_research/papers-2008.md
@@ -11,3 +11,21 @@ Jens Lincke, Robert Hirschfeld, Michael RÃ¼ger, and Maic Masuch. SophieScript - 
 Robert Hirschfeld, Michael Haupt, Michael RÃ¼ger, Patrick BrÃ¼nn, Ronny EsterluÃŸ, Norman Holz, Kerstin Knebel, and Robert Timm. SophieServer - The Future of Reading. In Proceedings of the Conference on Creating, Connecting and Collaborating through Computing (C5) 2008, pages 29-35, Poitiers, France, January 14-16, 2008, IEEE.
 
 Robert Hirschfeld, Pascal Costanza, and Michael Haupt. An Introduction to Context-oriented Programming with ContextS. In Generative and Transformational Techniques in Software Engineering (GTTSE) II, Springer LNCS 5235, pages 396-407, Braga, Portugal, July 2-7, 2008, Springer.
+
+Bergel Alexandre, Stéphane Ducasse, Oscar Nierstrasz, and Roel Wuyts. Stateful traits and their formalization. In: Computer Languages, Systems & Structures No. 34 p.83–108, 2008.
+
+Bolz Carl Friedrich, Adrian Kuhn, Adrian Lienhard, Nicholas D. Matsakis, Oscar Nierstrasz, Lukas Renggli, Armin Rigo, and Toon Verwaest. Back to the Future in One Week-Implementing a Smalltalk VM in PyPy. In: S3 p.123–139, 2008, Springer.
+
+Denker Marcus, Mathieu Suen, and Stéphane Ducasse. The meta in meta-object architectures. In: Objects, Components, Models and Patterns p.218–237, 2008, Springer.
+
+Kuhn Adrian, and Oscar Nierstrasz. Composing new abstractions from object fragments. In: Proceedings of the 2nd Workshop on Virtual Machines and Intermediate Languages for emerging modularization mechanisms p.1, 2008, ACM.
+
+Lienhard Adrian, Tudor Gîrba, and Oscar Nierstrasz. Practical object-oriented back-in-time debugging. In: Lecture Notes in Computer Science No. 5142 p.592–615, 2008.
+
+Röthlisberger David. Embedding Moose Facilities Directly in IDEs. 2008.
+
+Röthlisberger David. Querying runtime information in the ide. In: Proceedings of the 2008 workshop on Query Technologies and Applications for Program Comprehension (QTAPC 2008), 2008.
+
+Röthlisberger David, Marcus Denker, and Éric Tanter. Unanticipated partial behavioral reflection: Adapting applications at runtime. In: Computer Languages, Systems & Structures No. 34 p.46–65, 2008.
+
+Rothlisberger David, Orla Greevy, and Oscar Nierstrasz. Exploiting runtime information in the IDE. In: Program Comprehension, 2008. ICPC 2008. The 16th IEEE International Conference on p.63–72, 2008, IEEE.

--- a/_research/papers-2009.md
+++ b/_research/papers-2009.md
@@ -12,3 +12,15 @@ Thomas Kowark, Robert Hirschfeld, and Michael Haupt. Object-Relational Mapping w
 Philipp Engelhard, Robert Hirschfeld, and Jens Lincke. Pitsupai - Collaborative Scripting in a distributed, persistent 3D World. In Proceedings of the Conference on Creating, Connecting and Collaborating through Computing (C5) 2009, pages 87-94, Kyoto, Japan, January 19-22, 2009, IEEE.
 
 Norman Holz, Robert Hirschfeld, Jens Lincke, Michael RÃ¼ger, and Michael Haupt. Sophie - Tools and Materials in Multimedia Book Creation. In Proceedings of the Conference on Creating, Connecting and Collaborating through Computing (C5) 2009, pages 20-26, Kyoto, Japan, January 19-22, 2009, IEEE.
+
+Haldiman Niklaus, Marcus Denker, and Oscar Nierstrasz. Practical, pluggable types for a dynamic language. In: Computer Languages, Systems & Structures No. 35 p.48–62, 2009.
+
+Lienhard Adrian, Stéphane Ducasse, and Tudor Girba. Taking an object-centric view on dynamic information with object flow analysis. In: Computer Languages, Systems & Structures No. 35 p.63–79, 2009.
+
+Röthlisberger David, Oscar Nierstrasz, Alexandre Bergel, and Stéphane Ducasse. Tackling software navigation issues of the Smalltalk IDE. In: Proceedings of the International Workshop on Smalltalk Technologies p.58–67, 2009, ACM.
+
+Röthlisberger David, Oscar Nierstrasz, and Stéphane Ducasse. Autumn leaves: Curing the window plague in IDEs. In: Reverse Engineering, 2009. WCRE’09. 16th Working Conference on p.237–246, 2009, IEEE.
+
+Röthlisberger David, Oscar Nierstrasz, Stéphane Ducasse, Damien Pollet, and Romain Robbes. Supporting task-oriented navigation in IDEs with configurable HeatMaps. In: Program Comprehension, 2009. ICPC’09. IEEE 17th International Conference on p.253–257, 2009, IEEE.
+
+Verwaest Toon, and Lukas Renggli. Safe reflection through polymorphism. In: Proceedings of the first international workshop on Context-aware software technology and applications p.21–24, 2009, ACM.

--- a/_research/papers-2011.md
+++ b/_research/papers-2011.md
@@ -9,3 +9,7 @@ Michael Perscheid, Michael Haupt, Robert Hirschfeld, and Hidehiko Masuhara. Test
 Michael Haupt, Michael Perscheid, and Robert Hirschfeld. Type Harvesting: A Practical Approach to Obtaining Typing Information in Dynamic Programming Languages. In Proceedings of the Object-oriented Programming Languages and Systems (OOPS) Track of the ACM Symposium on Applied Computing (SAC) 2011, pages 1282-1289, Tunghai University, TaiChung, Taiwan, March 21-24, 2011, ACM Press.
 
 Robert Hirschfeld, Bastian Steinert, and Jens Lincke. Agile Software Development in Virtual Collaboration Environments. In Hasso Plattner, Christoph Meinel, and Larry Leifer (eds.). Design Thinking: Understand-Improve-Apply. pages 197-218, Springer 2011, doi:10.1007/978-3-642-13757-0_12.
+
+Bergel Alexandre, Oscar Nierstrasz, Lukas Renggli, and Jorge Ressia. Domain-specific profiling. In: Objects, Models, Components, Patterns p.68–82, 2011, Springer.
+
+Robbes R., E. Tanter, and D. Rothlisberger. How developers use the dynamic features of programming languages: the case of smalltalk. In: Proceedings of the International Working Conference on Mining Software Repositories, 2011.

--- a/_research/papers-2012.md
+++ b/_research/papers-2012.md
@@ -15,3 +15,23 @@ Michael Perscheid, Michael Haupt, Robert Hirschfeld, and Hidehiko Masuhara. Test
 Michael Perscheid, Damien Cassou, and Robert Hirschfeld. Test Quality Feedback: Improving Effectivity and Efficiency of Unit Testing. In Proceedings of the Conference on Creating, Connecting and Collaborating through Computing (C5) 2012, pages 60-67, Institute for Creative Technologies, University of Southern California, Playa Vista, California, USA, January 18-20, 2012, IEEE.
 
 Lauritz Thamsen, Anton Gulenko, Michael Perscheid, Robert Krahn, Robert Hirschfeld, and David A. Thomas. Orca: A Single-language Web Framework for Collaborative Development. In Proceedings of the Conference on Creating, Connecting and Collaborating through Computing (C5) 2012, pages 45-52, Institute for Creative Technologies, University of Southern California, Playa Vista, California, USA, January 18-20, 2012, IEEE.
+
+Nierstrasz Oscar, and Mircea Lungu. Agile software assessment. In: Program Comprehension (ICPC), 2012 IEEE 20th International Conference on p.3–10, 2012, IEEE.
+
+Ressia Jorge, Alexandre Bergel, and Oscar Nierstrasz. Object-centric debugging. In: Proceedings of the 34th International Conference on Software Engineering p.485–495, 2012, IEEE Press.
+
+Ressia Jorge, Alexandre Bergel, Oscar Nierstrasz, and Lukas Renggli. Modeling Domain-Specific Profilers. In: Journal of Object Technology No. 11 p.1–21, 2012.
+
+Ressia Jorge, Fabrizio Perin, and Lukas Renggli. Suicide objects. In: Proceedings of the 6th Workshop on Dynamic Languages and Applications p.1, 2012, ACM.
+
+Robbes Romain, Mircea Lungu, and David Röthlisberger. How do developers react to api deprecation?: the case of a smalltalk ecosystem. In: Proceedings of the ACM SIGSOFT 20th International Symposium on the Foundations of Software Engineering p.56, 2012, ACM.
+
+Schwarz Niko. Hot clones: combining search-driven development, clone management, and code provenance. In: Proceedings of the 34th International Conference on Software Engineering p.1628–1629, 2012, IEEE Press.
+
+Schwarz Niko, Mircea Lungu, and Oscar Nierstrasz. Seuss: Decoupling responsibilities from static methods for fine-grained configurability. In: Journal of Object Technology No. 11 p.1–23, 2012.
+
+Schwarz Niko, Mircea Lungu, and Romain Robbes. On how often code is cloned across repositories. In: Proceedings of the 34th International Conference on Software Engineering p.1289–1292, 2012, IEEE Press.
+
+Wernli Erwann, Mircea Lungu, and Oscar Nierstrasz. Incremental dynamic updates with first-class contexts. In: Objects, Models, Components, Patterns p.304–319, 2012, Springer.
+
+Wernli Erwann, Pascal Maerki, and Oscar Nierstrasz. Ownership, filters and crossing handlers. In: Dynamic Language Symposium (DLS), 2012.

--- a/_research/papers-2013.md
+++ b/_research/papers-2013.md
@@ -3,3 +3,9 @@ order:      2013
 category:   2013
 ---
 Tim Felgentreff, Michael Perscheid, and Robert Hirschfeld. Constraining Timing-dependent Communication for Debugging Non-deterministic Failures. In Proceedings of the Fourth International Workshop on Academic Software Development Tools and Techniques (WASDeTT-4) 2013, co-located with the European Conference on Object-oriented Programming (ECOOP) 2013, Montpellier, France, July 1, 2013.
+
+Aeschlimann Erik, Mircea Lungu, Oscar Nierstrasz, and Carl Worms. Analyzing PL/1 legacy ecosystems: An experience report. In: Reverse Engineering (WCRE), 2013 20th Working Conference on p.441–448, 2013, IEEE.
+
+Chis Andrei, Oscar Nierstrasz, and Tudor Gîrba. Towards a moldable debugger. In: Proceedings of the 7th Workshop on Dynamic Languages and Applications p.2, 2013, ACM.
+
+Haenni Nicole, Mircea Lungu, Niko Schwarz, and Oscar Nierstrasz. Categorizing developer information needs in software ecosystems. In: Proceedings of the 2013 International Workshop on Ecosystem Architectures p.1–5, 2013, ACM.

--- a/_research/papers-2014.md
+++ b/_research/papers-2014.md
@@ -21,3 +21,21 @@ Bastian Steinert and Robert Hirschfeld. How to Compare Performance in Program De
 Michael Perscheid, Tim Felgentreff, and Robert Hirschfeld. Follow the Path: Debugging State Anomalies Along Execution Histories. In Proceedings of the IEEE European Conference on Software Maintenance and Reengineering and the Working Conference on Reverse Engineering (CSMR-WCRE) 2014 Software Evolution Week, pages 124-133, Antwerp, Belgium, February 3-6, 2014, IEEE.
 
 Michael Perscheid and Robert Hirschfeld. Follow the Path: Debugging Tools for Test-driven Fault Navigation. In Tool Demo Track of the IEEE European Conference on Software Maintenance and Reengineering and the Working Conference on Reverse Engineering (CSMR-WCRE) 2014 Software Evolution Week, pages 446-449, Antwerp, Belgium, February 3-6, 2014, IEEE.
+
+Caracciolo Andrea, Andrei Chis, Boris Spasojevic, and Mircea Lungu. Pangea: A workbench for statically analyzing multi-language software corpora. In: Source Code Analysis and Manipulation (SCAM), 2014 IEEE 14th International Working Conference on p.71–76, 2014, IEEE.
+
+Chis Andrei, Tudor Gîrba, and Oscar Nierstrasz. The Moldable Debugger: a framework for developing domain-specific debuggers. In: Software Language Engineering p.102–121, 2014, Springer.
+
+Chis Andrei, Oscar Nierstrasz, and Tudor Girba. The Moldable Inspector: a framework for domain-specific object inspection. In: Proceedings of International Workshop on Smalltalk Technologies (IWST 2014), 2014.
+
+Haenni Nicole, Mircea Lungu, Niko Schwarz, and Oscar Nierstrasz. A quantitative analysis of developer information needs in software ecosystems. In: Proceedings of the 2014 European Conference on Software Architecture Workshops p.12, 2014, ACM.
+
+Merino Leonel. Adaptable Visualisation Based On User Needs. In: SATToSE 2014—Pre-proceedings p.71, 2014.
+
+Ressia Jorge, Tudor Gîrba, Oscar Nierstrasz, Fabrizio Perin, and Lukas Renggli. Talents: an environment for dynamically composing units of reuse. In: Software: Practice and Experience No. 44 p.413–432, 2014.
+
+Spasojevic Boris, Mircea Lungu, and Oscar Nierstrasz. Overthrowing the tyranny of alphabetical ordering in documentation systems. In: Software Maintenance and Evolution (ICSME), 2014 IEEE International Conference on p.511–515, 2014, IEEE.
+
+Spasojevic Boris, Mircea Lungu, and Oscar Nierstrasz. Towards faster method search through static ecosystem analysis. In: Proceedings of the 2014 European Conference on Software Architecture Workshops p.11, 2014, ACM.
+
+Spasojeviu Boris, Mircea Lungu, and Oscar Nierstrasz. Mining the Ecosystem to Improve Type Inference for Dynamically Typed Languages. In: Proceedings of the 2014 ACM International Symposium on New Ideas, New Paradigms, and Reflections on Programming & Software p.133–142, 2014, ACM.

--- a/_research/papers-2015.md
+++ b/_research/papers-2015.md
@@ -3,3 +3,9 @@ order:      2015
 category:   2015
 ---
 Tim Felgentreff, Tobias Pape, Lars Wassermann, Robert Hirschfeld, and Carl Friedrich Bolz. Towards Reducing the Need for Algorithmic Primitives in Dynamic Language VMs Through a Tracing JIT. In Proceedings of the Workshop on Implementation, Compilation, Optimization of Object-Oriented Languages, Programs and Systems (ICOOOLPS) 2015, co-located with the European Conference on Object-oriented Programming (ECOOP), Prague, Czech Republic, July 6, 2015, ACM DL.
+
+Caracciolo Andrea, Mircea Filip Lungu, and Oscar Nierstrasz. A Unified Approach to Architecture Conformance Checking. In: Proceedings of the 12th Working IEEE/IFIP Conference on Software Architecture (WICSA), ACM Press, 2015.
+
+Merino Leonel, Mircea Lungu, and Oscar Nierstrasz. Explora: Infrastructure for Scaling Up Software Visualisation to Corpora. 2015.
+
+Milojkovic Nevena, Andrea Caracciolo, Mircea Filip Lungu, Oscar Nierstrasz, David Röthlisberger, and Romain Robbes. Polymorphism in the Spotlight: Studying Its Prevalence in Java and Smalltalk. 2015.


### PR DESCRIPTION
These are all papers about projects from the scg group using Squeak as an implementation platform or as an example for an evaluation.

Can someone please check whether the reference style matches the targeted?

How should we go about the ordering? Currently I've just put the new references underneath the existing ones.